### PR TITLE
JSON Decoder Update 

### DIFF
--- a/src/api/tscjson_decode.c
+++ b/src/api/tscjson_decode.c
@@ -1,63 +1,36 @@
 #include <stdlib.h> // fuck you floats
-                    // also we need it for string allocations
 
 #include "tscjson.h"
 #include "tscjson_macros.h"
 
-#define TSC_JSON_CALL(thing, another_thing) do { \
+// heheheha
+// Yo what the freak! 2 oooooOOoOOoOOOOoOOOOoOOOOoOOoO KL[oKLP[]
+
+#define TSC_JSON_ERROR(err, idx) ((tsc_json_error_t) { (uint32_t)(TSC_JSON_PARSE_ERROR_##err), (uint32_t)(idx) })
+#define TSC_JSON_SUCCESS ((tsc_json_error_t) { (uint32_t)(TSC_JSON_ERROR_SUCCESS), 0 })
+
+#define TSC_JSON_CALL(thing) do { \
     tsc_json_error_t result = thing; \
     if (result.status != TSC_JSON_ERROR_SUCCESS) { \
-        another_thing; \
         return result; \
     } \
 } while (0)
 
-#define TSC_JSON_ERROR(err, idx) ((tsc_json_error_t) { (uint32_t)(TSC_JSON_PARSE_ERROR_##err), (uint32_t)(idx) })
-#define TSC_JSON_SUCCESS ((tsc_json_error_t) { (uint32_t)(TSC_JSON_ERROR_SUCCESS), 0 })
-#define TSC_JSON_EXPECT_CHAR(expected_char, error_code, thing) do { \
-    TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), thing); \
+#define TSC_JSON_MEASURE_EXPECT_CHAR(expected_char, error_code) do { \
+    TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx)); \
     if ((s[(*idx)++]) != expected_char) { \
-        thing; \
         return TSC_JSON_ERROR(error_code, *idx - 1); \
     } \
 } while (0)
 
-static void tsc_json_skip_line_comment(
+static tsc_json_error_t tsc_json_measure_skip_whitespace(
         const char *s,
         size_t *idx
 ) {
     while (1) {
-        const unsigned char c = s[(*idx)];
-        *idx += c != '\0';
-        if (c == '\0' || c == '\n') break;
-    }
-}
-
-static tsc_json_error_t tsc_json_skip_block_comment(
-        const char *s,
-        size_t *idx
-) {
-    const size_t start = *idx;
-    while (1) {
-        const char c = s[(*idx)++];
-        if (c == '\0') {
-            return TSC_JSON_ERROR(UNTERMINATED_MULTILINE_COMMENT, start);
-        }
-        if (c == '*' && s[*idx] == '/') {
-            (*idx)++;
-            return TSC_JSON_SUCCESS;
-        }
-    }
-}
-
-static tsc_json_error_t tsc_json_skip_whitespace(
-        const char *s,
-        size_t *idx
-) {
-    while (1) {
-        char c = s[*idx];
+        unsigned char c = s[*idx];
         if (c == '\0') break;
-        if (isspace(c)) {
+        if (TSC_JSON_ISSPACE[c]) {
             (*idx)++;
             continue;
         }
@@ -66,11 +39,25 @@ static tsc_json_error_t tsc_json_skip_whitespace(
             (*idx)++;
             c = s[(*idx)++];
             if (c == '/') {
-                tsc_json_skip_line_comment(s, idx);
+                while (1) {
+                    c = s[(*idx)];
+                    *idx += c != '\0';
+                    if (c == '\0' || c == '\n') break;
+                }
                 continue;
             }
             if (c == '*') {
-                TSC_JSON_CALL(tsc_json_skip_block_comment(s, idx), ;);
+                const size_t start = *idx;
+                while (1) {
+                    c = s[(*idx)++];
+                    if (c == '\0') {
+                        return TSC_JSON_ERROR(UNTERMINATED_MULTILINE_COMMENT, start);
+                    }
+                    if (c == '*' && s[*idx] == '/') {
+                        (*idx)++;
+                        break;
+                    }
+                }
                 continue;
             }
 
@@ -82,272 +69,219 @@ static tsc_json_error_t tsc_json_skip_whitespace(
     return TSC_JSON_SUCCESS;
 }
 
-static int tsc_json_utf8_encode(
-        const unsigned int cp,
-        char *p
+static int tsc_json_measure_number(
+        const char* s,
+        size_t* idx
 ) {
-    if (cp <= 0x7F) {
-        p[0] = cp;
-        return 1;
+    const size_t start = *idx;
+    size_t pos = start;
+    int can_be_float = 1;
+
+    if (s[pos] == '-') pos++;
+
+    if (s[pos] == '0') {
+        pos++;
+        if (s[pos] == 'x') {
+            can_be_float = 0;
+            pos++;
+            if (!TSC_JSON_ISXDIGIT[(unsigned char)s[pos]]) return 0;
+            while (TSC_JSON_ISXDIGIT[(unsigned char)s[pos]]) pos++;
+        }
+        else if (s[pos] == 'b') {
+            can_be_float = 0;
+            pos++;
+            if (s[pos] != '0' && s[pos] != '1') return 0;
+            while (s[pos] == '0' || s[pos] == '1') pos++;
+        }
+        // after a leading zero we can only have '.' 'e' or end of whatever
+        // because we don't have octals
+        else {
+            if (TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) return 0;
+
+            if (s[pos] != '\0' &&
+                s[pos] != '.' &&
+                s[pos] != 'e' &&
+                s[pos] != 'E' &&
+                !TSC_JSON_ISSPACE[(unsigned char)s[pos]] &&
+                s[pos] != ',' &&
+                s[pos] != '}' &&
+                s[pos] != ']'
+            ) return 0;
+        }
     }
-    if (cp <= 0x7FF) {
-        p[0] = 0xC0 | cp >> 6;
-        p[1] = 0x80 | cp & 0x3F;
-        return 2;
+    else if (TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) {
+        pos++;
+        while (TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) pos++;
     }
-    if (cp <= 0xFFFF) {
-        p[0] = 0xE0 | cp >> 12;
-        p[1] = 0x80 | cp >> 6 & 0x3F;
-        p[2] = 0x80 | cp & 0x3F;
-        return 3;
+    else return 0;
+
+    if (can_be_float) {
+        if (s[pos] == '.') {
+            pos++;
+            if (!TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) return 0;
+            while (TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) pos++;
+        }
+
+        if (s[pos] == 'e' || s[pos] == 'E') {
+            pos++;
+            if (s[pos] == '+' || s[pos] == '-') pos++;
+
+            if (!TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) return 0;
+            while (TSC_JSON_ISDIGIT[(unsigned char)s[pos]]) pos++;
+        }
     }
-    p[0] = 0xF0 | cp >> 18;
-    p[1] = 0x80 | cp >> 12 & 0x3F;
-    p[2] = 0x80 | cp >> 6 & 0x3F;
-    p[3] = 0x80 | cp & 0x3F;
-    return 4;
+
+    *idx = pos;
+    return 1; // yes this is a valid number
 }
 
-static tsc_json_error_t tsc_json_calculate_string_length(
+static tsc_json_error_t tsc_json_measure_string(
         const char *s,
-        size_t start_idx,
-        size_t *out_length
+        size_t *idx
 ) {
-    size_t length = 1;
-    size_t temp_idx = start_idx;
+    const size_t start = *idx - 1;
 
     while (1) {
-        const char c = s[temp_idx];
+        const char c = s[*idx];
         if ((unsigned char)c < ' ') {
-            return TSC_JSON_ERROR(UNTERMINATED_STRING, start_idx - 1);
+            return TSC_JSON_ERROR(UNTERMINATED_STRING, start);
         }
         if (c == '"') {
+            (*idx)++;
             break;
         }
         if (c == '\\') {
-            temp_idx++;
-            const char esc = s[temp_idx];
+            (*idx)++;
+
+            const char esc = s[(*idx)++];
             if (esc == '\0') {
-                return TSC_JSON_ERROR(UNTERMINATED_STRING, start_idx - 1);
+                return TSC_JSON_ERROR(UNTERMINATED_STRING, start);
             }
-            temp_idx++;
 
             if (TSC_JSON_BACKSLASH[(unsigned char)esc]) {
-                length++;
+                // good
             }
             else if (esc == 'x') {
-                if (!isxdigit(s[temp_idx]) || !isxdigit(s[temp_idx + 1])) {
-                    return TSC_JSON_ERROR(INVALID_xXX_ESCAPE, temp_idx);
+                if (!TSC_JSON_ISXDIGIT[(unsigned char)s[*idx]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 1]]) {
+                        return TSC_JSON_ERROR(INVALID_xXX_ESCAPE, *idx);
                 }
-                temp_idx += 2;
-                length += 1;
             }
             else if (esc == 'u') {
-                if (!isxdigit(s[temp_idx]) || !isxdigit(s[temp_idx + 1]) ||
-                    !isxdigit(s[temp_idx + 2]) || !isxdigit(s[temp_idx + 3])) {
-                    return TSC_JSON_ERROR(INVALID_uXXXX_ESCAPE, temp_idx);
+                if (!TSC_JSON_ISXDIGIT[(unsigned char)s[*idx]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 1]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 2]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 3]]) {
+                        return TSC_JSON_ERROR(INVALID_uXXXX_ESCAPE, *idx);
                 }
 
-                const unsigned int cp =
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx]] << 12 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 1]] << 8 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 2]] << 4 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 3]];
-
-                temp_idx += 4;
-
-                if (cp <= 0x7F) {
-                    length += 1;
-                }
-                else if (cp <= 0x7FF) {
-                    length += 2;
-                }
-                else {
-                    length += 3;
-                }
-            }
-            else if (esc == 'U') {
-                if (!isxdigit(s[temp_idx]) || !isxdigit(s[temp_idx + 1]) ||
-                    !isxdigit(s[temp_idx + 2]) || !isxdigit(s[temp_idx + 3]) ||
-                    !isxdigit(s[temp_idx + 4]) || !isxdigit(s[temp_idx + 5]) ||
-                    !isxdigit(s[temp_idx + 6]) || !isxdigit(s[temp_idx + 7])) {
-                    return TSC_JSON_ERROR(INVALID_UXXXXXXXX_ESCAPE, temp_idx);
-                }
-
-                const unsigned int cp =
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx]] << 28 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 1]] << 24 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 2]] << 20 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 3]] << 16 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 4]] << 12 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 5]] << 8 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 6]] << 4 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[temp_idx + 7]];
-
-                temp_idx += 8;
-
-                if (cp <= 0x7F) {
-                    length += 1;
-                }
-                else if (cp <= 0x7FF) {
-                    length += 2;
-                }
-                else if (cp <= 0xFFFF) {
-                    length += 3;
-                }
-                else {
-                    length += 4;
-                }
-            }
-            else {
-                return TSC_JSON_ERROR(BAD_BACKSLASH, temp_idx);
-            }
-            continue;
-        }
-
-        const unsigned char b0 = (unsigned char)s[temp_idx];
-
-        if ((b0 & 0x80) == 0) {
-            temp_idx++;
-            length += 1;
-        }
-        else if ((b0 & 0xE0) == 0xC0) {
-            if (s[temp_idx + 1] == '\0' ||
-                (s[temp_idx + 1] & 0xC0) != 0x80 ||
-                b0 < 0xC2) {
-                return TSC_JSON_ERROR(BAD_UTF8, temp_idx);
-            }
-            temp_idx += 2;
-            length += 2;
-        }
-        else if ((b0 & 0xF0) == 0xE0) {
-            if (s[temp_idx + 1] == '\0' || s[temp_idx + 2] == '\0' ||
-                (s[temp_idx + 1] & 0xC0) != 0x80 ||
-                (s[temp_idx + 2] & 0xC0) != 0x80 ||
-                (b0 == 0xE0 && (unsigned char)s[temp_idx + 1] < 0xA0) ||
-                (b0 == 0xED && (unsigned char)s[temp_idx + 1] >= 0xA0)) {
-                return TSC_JSON_ERROR(BAD_UTF8, temp_idx);
-            }
-            temp_idx += 3;
-            length += 3;
-        }
-        else if ((b0 & 0xF8) == 0xF0) {
-            if (s[temp_idx + 1] == '\0' || s[temp_idx + 2] == '\0' || s[temp_idx + 3] == '\0' ||
-                (s[temp_idx + 1] & 0xC0) != 0x80 ||
-                (s[temp_idx + 2] & 0xC0) != 0x80 ||
-                (s[temp_idx + 3] & 0xC0) != 0x80 ||
-                (b0 == 0xF0 && (unsigned char)s[temp_idx + 1] < 0x90) ||
-                (b0 > 0xF4 || (b0 == 0xF4 && (unsigned char)s[temp_idx + 1] > 0x8F))) {
-                return TSC_JSON_ERROR(BAD_UTF8, temp_idx);
-            }
-            temp_idx += 4;
-            length += 4;
-        }
-        else {
-            return TSC_JSON_ERROR(BAD_UTF8, temp_idx);
-        }
-    }
-
-    *out_length = length;
-    return TSC_JSON_SUCCESS;
-}
-
-static tsc_json_error_t tsc_json_decode_string(
-        const char *s,
-        size_t *idx,
-        char **out
-) {
-    size_t needed_length;
-    TSC_JSON_CALL(tsc_json_calculate_string_length(s, *idx, &needed_length), ;);
-    char *buf = malloc(needed_length);
-    size_t buf_idx = 0;
-
-    while (s[*idx] != '"') {
-        const char c = s[*idx];
-
-        if (c == '\\') {
-            (*idx)++;
-            const char esc = s[*idx];
-            (*idx)++;
-
-            if (TSC_JSON_BACKSLASH[(unsigned char)esc]) {
-                buf[buf_idx++] = TSC_JSON_BACKSLASH[(unsigned char)esc];
-            }
-            else if (esc == 'x') {
-                const unsigned int cp =
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx]] << 4 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 1]];
-                *idx += 2;
-                buf_idx += tsc_json_utf8_encode(cp, buf + buf_idx); // Pass the correct buffer offset
-            }
-            else if (esc == 'u') {
                 const unsigned int cp =
                     (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx]] << 12 |
                     (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 1]] << 8 |
                     (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 2]] << 4 |
                     (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 3]];
+
                 *idx += 4;
-                buf_idx += tsc_json_utf8_encode(cp, buf + buf_idx); // Pass the correct buffer offset
+
+                if (0xd800 <= cp && cp <= 0xdbff) {
+                    if (s[*idx] != '\\' || s[*idx + 1] != 'u') {
+                        return TSC_JSON_ERROR(INVALID_uXXXX_ESCAPE, *idx);
+                    }
+                    *idx += 2;
+                    if (!TSC_JSON_ISXDIGIT[(unsigned char)s[*idx]] ||
+                        !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 1]] ||
+                        !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 2]] ||
+                        !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 3]]) {
+                            return TSC_JSON_ERROR(INVALID_uXXXX_ESCAPE, *idx);
+                    }
+                    const unsigned int cp2 =
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx]] << 12 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 1]] << 8 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 2]] << 4 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 3]];
+                    if (0xdc00 <= cp2 && cp2 <= 0xdfff) {
+                        *idx += 4;
+                    }
+                    else {
+                        return TSC_JSON_ERROR(INVALID_uXXXX_ESCAPE, *idx);
+                    }
+                }
             }
             else if (esc == 'U') {
-                const unsigned int cp =
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx]] << 28 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 1]] << 24 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 2]] << 20 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 3]] << 16 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 4]] << 12 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 5]] << 8 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 6]] << 4 |
-                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[*idx + 7]];
+                if (!TSC_JSON_ISXDIGIT[(unsigned char)s[*idx]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 1]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 2]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 3]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 4]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 5]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 6]] ||
+                    !TSC_JSON_ISXDIGIT[(unsigned char)s[*idx + 7]]) {
+                        return TSC_JSON_ERROR(INVALID_UXXXXXXXX_ESCAPE, *idx);
+                }
+
                 *idx += 8;
-                buf_idx += tsc_json_utf8_encode(cp, buf + buf_idx); // Pass the correct buffer offset
             }
+            else {
+                return TSC_JSON_ERROR(BAD_BACKSLASH, *idx);
+            }
+            continue;
+        }
+
+        const unsigned char b0 = (unsigned char)s[*idx];
+        if ((b0 & 0x80) == 0) {
+            *idx += 1;
+        }
+        else if ((b0 & 0xE0) == 0xC0) {
+            if (s[*idx + 1] == '\0' ||
+                (s[*idx + 1] & 0xC0) != 0x80 ||
+                b0 < 0xC2) {
+                    return TSC_JSON_ERROR(BAD_UTF8, *idx);
+            }
+            *idx += 2;
+        }
+        else if ((b0 & 0xF0) == 0xE0) {
+            if (s[*idx + 1] == '\0' || s[*idx + 2] == '\0' ||
+                (s[*idx + 1] & 0xC0) != 0x80 ||
+                (s[*idx + 2] & 0xC0) != 0x80 ||
+                (b0 == 0xE0 && (unsigned char)s[*idx + 1] < 0xA0) ||
+                (b0 == 0xED && (unsigned char)s[*idx + 1] >= 0xA0)) {
+                    return TSC_JSON_ERROR(BAD_UTF8, *idx);
+            }
+            *idx += 3;
+        }
+        else if ((b0 & 0xF8) == 0xF0) {
+            if (s[*idx + 1] == '\0' || s[*idx + 2] == '\0' || s[*idx + 3] == '\0' ||
+                (s[*idx + 1] & 0xC0) != 0x80 ||
+                (s[*idx + 2] & 0xC0) != 0x80 ||
+                (s[*idx + 3] & 0xC0) != 0x80 ||
+                (b0 == 0xF0 && (unsigned char)s[*idx + 1] < 0x90) ||
+                (b0 > 0xF4 || (b0 == 0xF4 && (unsigned char)s[*idx + 1] > 0x8F))) {
+                    return TSC_JSON_ERROR(BAD_UTF8, *idx);
+            }
+            *idx += 4;
         }
         else {
-            const unsigned char b0 = (unsigned char)s[*idx];
-
-            if ((b0 & 0x80) == 0) {
-                buf[buf_idx++] = s[(*idx)++];
-            }
-            else if ((b0 & 0xE0) == 0xC0) {
-                buf[buf_idx++] = s[(*idx)++];
-                buf[buf_idx++] = s[(*idx)++];
-            }
-            else if ((b0 & 0xF0) == 0xE0) {
-                buf[buf_idx++] = s[(*idx)++];
-                buf[buf_idx++] = s[(*idx)++];
-                buf[buf_idx++] = s[(*idx)++];
-            }
-            else if ((b0 & 0xF8) == 0xF0) {
-                buf[buf_idx++] = s[(*idx)++];
-                buf[buf_idx++] = s[(*idx)++];
-                buf[buf_idx++] = s[(*idx)++];
-                buf[buf_idx++] = s[(*idx)++];
-            }
+            return TSC_JSON_ERROR(BAD_UTF8, *idx);
         }
     }
 
-    (*idx)++;
-    buf[buf_idx] = '\0';
-
-    *out = buf;
     return TSC_JSON_SUCCESS;
 }
 
-static tsc_json_error_t tsc_json_decode_any(
+static tsc_json_error_t tsc_json_measure_any(
     const char *s,
     size_t *idx,
-    tsc_value *out
+    int *stack_size
 );
 
-static tsc_json_error_t tsc_json_decode_object(
+static tsc_json_error_t tsc_json_measure_object(
         const char *s,
         size_t *idx,
-        tsc_value *out
+        int *stack_size
 ) {
-    *out = tsc_object();
+    (*stack_size)++;
 
-    TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), tsc_destroy(*out));
+    TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
 
     if (s[*idx] == '}') {
         (*idx)++;
@@ -355,24 +289,19 @@ static tsc_json_error_t tsc_json_decode_object(
     }
 
     while (1) {
-        TSC_JSON_EXPECT_CHAR('"', OBJECT_NO_KEY, tsc_destroy(*out));
-        char* key;
-        TSC_JSON_CALL(tsc_json_decode_string(s, idx, &key), tsc_destroy(*out));
+        TSC_JSON_MEASURE_EXPECT_CHAR('"', OBJECT_NO_KEY);
+        TSC_JSON_CALL(tsc_json_measure_string(s, idx));
+        (*stack_size)++;
 
-        TSC_JSON_EXPECT_CHAR(':', EXPECTED_COLON, tsc_destroy(*out));
+        TSC_JSON_MEASURE_EXPECT_CHAR(':', EXPECTED_COLON);
 
-        tsc_value value;
-        TSC_JSON_CALL(tsc_json_decode_any(s, idx, &value), tsc_destroy(*out));
-        tsc_setKey(*out, key, value);
-        free(key);
-        tsc_destroy(value);
-
-        TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), tsc_destroy(*out));
+        TSC_JSON_CALL(tsc_json_measure_any(s, idx, stack_size));
+        TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
 
         const char sep = s[(*idx)++];
         if (sep == '}') return TSC_JSON_SUCCESS;
         if (sep == ',') {
-            TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), tsc_destroy(*out));
+            TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
             if (s[*idx] == '}') {
                 (*idx)++;
                 return TSC_JSON_SUCCESS;
@@ -383,14 +312,14 @@ static tsc_json_error_t tsc_json_decode_object(
     }
 }
 
-static tsc_json_error_t tsc_json_decode_array(
+static tsc_json_error_t tsc_json_measure_array(
         const char *s,
         size_t *idx,
-        tsc_value *out
+        int *stack_size
 ) {
-    *out = tsc_array(0);
+    (*stack_size)++;
 
-    TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), tsc_destroy(*out));
+    TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
 
     if (s[*idx] == ']') {
         (*idx)++;
@@ -398,18 +327,14 @@ static tsc_json_error_t tsc_json_decode_array(
     }
 
     while (1) {
-        tsc_value value;
-        TSC_JSON_CALL(tsc_json_decode_any(s, idx, &value), tsc_destroy(*out));
-        tsc_append(*out, value);
-        tsc_destroy(value);
-
-        TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), tsc_destroy(*out));
+        TSC_JSON_CALL(tsc_json_measure_any(s, idx, stack_size));
+        TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
 
         const char sep = s[(*idx)++];
         if (sep == ']') return TSC_JSON_SUCCESS;
 
         if (sep == ',') {
-            TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), tsc_destroy(*out));
+            TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
             if (s[*idx] == ']') {
                 (*idx)++;
                 return TSC_JSON_SUCCESS;
@@ -420,194 +345,27 @@ static tsc_json_error_t tsc_json_decode_array(
     }
 }
 
-// oh shit
-static int tsc_json_decode_number(
-        const char* s,
-        size_t* idx,
-        tsc_value* out
-) {
-    const size_t start = *idx;
-    size_t pos = start;
-    int is_float = 0;
-    int is_hex = 0;
-    int is_bin = 0;
-
-    if (s[pos] == '-') pos++;
-
-    if (s[pos] == '0') {
-        pos++;
-        if (s[pos] == 'x') {
-            is_hex = 1;
-            pos++;
-            if (!isxdigit(s[pos])) return 0;
-            while (isxdigit(s[pos])) pos++;
-        }
-        else if (s[pos] == 'b') {
-            is_bin = 1;
-            pos++;
-            if (s[pos] != '0' && s[pos] != '1') return 0;
-            while (s[pos] == '0' || s[pos] == '1') pos++;
-        }
-        // after a leading zero we can only have '.' 'e' or end of whatever
-        // because we don't have octals
-        else {
-            if (isdigit(s[pos])) return 0;
-
-            if (s[pos] != '\0' &&
-                s[pos] != '.' &&
-                s[pos] != 'e' &&
-                s[pos] != 'E' &&
-                !isspace(s[pos]) &&
-                s[pos] != ',' &&
-                s[pos] != '}' &&
-                s[pos] != ']'
-            ) return 0;
-        }
-    }
-    else if (isdigit(s[pos])) {
-        pos++;
-        while (isdigit(s[pos])) pos++;
-    }
-    else return 0;
-
-    if (!is_hex && !is_bin) {
-        if (s[pos] == '.') {
-            is_float = 1;
-            pos++;
-            if (!isdigit(s[pos])) return 0;
-            while (isdigit(s[pos])) pos++;
-        }
-
-        if (s[pos] == 'e' || s[pos] == 'E') {
-            is_float = 1;
-            pos++;
-            if (s[pos] == '+' || s[pos] == '-') pos++;
-
-            if (!isdigit(s[pos])) return 0;
-            while (isdigit(s[pos])) pos++;
-        }
-    }
-
-    *idx = pos;
-
-    if (is_float) {
-        // TODO: make it not use FPU and glibc
-        *out = tsc_number(atof(s + start));
-    }
-    else if (is_bin) {
-        int64_t result = 0;
-        size_t i = start;
-
-        const int sign = s[i] == '-' ? -1 : 1;
-        if (s[i] == '-') i++;
-
-        i += 2;
-
-        while (i < pos && (s[i] == '0' || s[i] == '1')) {
-            if (result > INT64_MAX / 2 || (result == INT64_MAX / 2 && s[i] - '0' > INT64_MAX % 2)) {
-                double dresult = (double)result;
-                while (i < pos && (s[i] == '0' || s[i] == '1')) {
-                    dresult = dresult * 2.0 + (s[i] - '0');
-                    i++;
-                }
-                *out = tsc_number(dresult * sign);
-                return 0;
-            }
-            result = result * 2 + (s[i] - '0');
-            i++;
-        }
-
-        *out = tsc_int(result * sign);
-    }
-    else if (is_hex) {
-        int64_t result = 0;
-        size_t i = start;
-
-        const int sign = s[i] == '-' ? -1 : 1;
-        if (s[i] == '-') i++;
-
-        i += 2;
-
-        while (i < pos && isxdigit(s[i])) {
-            unsigned digit_val = TSC_JSON_XDIGIT[(unsigned char)s[i]];
-            if (result > INT64_MAX / 16 || (result == INT64_MAX / 16 && digit_val > (INT64_MAX % 16))) {
-                double dresult = (double)result;
-                while (i < pos && isxdigit(s[i])) {
-                    dresult = dresult * 16.0 + TSC_JSON_XDIGIT[(unsigned char)s[i]];
-                    i++;
-                }
-                *out = tsc_number(dresult * sign);
-                return 0;
-            }
-            result = result * 16 + digit_val;
-            i++;
-        }
-
-        *out = tsc_int(result * sign);
-    }
-    else {
-        int64_t result = 0;
-        size_t i = start;
-
-        const int sign = s[i] == '-' ? -1 : 1;
-        if (s[i] == '-') i++;
-
-        while (i < pos && isdigit(s[i])) {
-            if (sign == -1) {
-                if (result > INT64_MIN / -10 ||
-                    (result == INT64_MIN / -10 && s[i] - '0' > -(INT64_MIN % 10))) {
-                    double dresult = (double)result;
-                    while (i < pos && isdigit(s[i])) {
-                        dresult = dresult * 10.0 + (s[i] - '0');
-                        i++;
-                    }
-                    *out = tsc_number(dresult * sign);
-                    return 0;
-                }
-            }
-            else {
-                if (result > INT64_MAX / 10 || (result == INT64_MAX / 10 && s[i] - '0' > INT64_MAX % 10)) {
-                    double dresult = (double)result;
-                    while (i < pos && isdigit(s[i])) {
-                        dresult = dresult * 10.0 + (s[i] - '0');
-                        i++;
-                    }
-                    *out = tsc_number(dresult * sign);
-                    return 0;
-                }
-            }
-            result = result * 10 + (s[i] - '0');
-            i++;
-        }
-
-        *out = tsc_int(result * sign);
-    }
-    return 1;
-}
-
-static tsc_json_error_t tsc_json_decode_any(
+static tsc_json_error_t tsc_json_measure_any(
         const char *s,
         size_t *idx,
-        tsc_value *out
+        int *stack_size
 ) {
-    TSC_JSON_CALL(tsc_json_skip_whitespace(s, idx), ;);
+    TSC_JSON_CALL(tsc_json_measure_skip_whitespace(s, idx));
     const char c = s[(*idx)++];
 
     if (c == '{') {
-        TSC_JSON_CALL(tsc_json_decode_object(s, idx, out), ;);
+        TSC_JSON_CALL(tsc_json_measure_object(s, idx, stack_size));
         return TSC_JSON_SUCCESS;
     }
 
     if (c == '[') {
-        TSC_JSON_CALL(tsc_json_decode_array(s, idx, out), ;);
+        TSC_JSON_CALL(tsc_json_measure_array(s, idx, stack_size));
         return TSC_JSON_SUCCESS;
     }
 
     if (c == '"') {
-        char* buf;
-        TSC_JSON_CALL(tsc_json_decode_string(s, idx, &buf), ;);
-        *out = tsc_string(buf);
-        free(buf);
+        TSC_JSON_CALL(tsc_json_measure_string(s, idx));
+        (*stack_size)++;
         return TSC_JSON_SUCCESS;
     }
 
@@ -617,7 +375,6 @@ static tsc_json_error_t tsc_json_decode_any(
         s[*idx + 2] == 'e'
     ) {
         *idx += 3;
-        *out = tsc_boolean(1);
         return TSC_JSON_SUCCESS;
     }
 
@@ -628,7 +385,6 @@ static tsc_json_error_t tsc_json_decode_any(
         s[*idx + 3] == 'e'
     ) {
         *idx += 4;
-        *out = tsc_boolean(0);
         return TSC_JSON_SUCCESS;
     }
 
@@ -638,7 +394,6 @@ static tsc_json_error_t tsc_json_decode_any(
         s[*idx + 2] == 'l'
     ) {
         *idx += 3;
-        *out = tsc_null();
         return TSC_JSON_SUCCESS;
     }
 
@@ -647,7 +402,6 @@ static tsc_json_error_t tsc_json_decode_any(
         s[*idx + 1] == 'N'
     ) {
         *idx += 2;
-        *out = tsc_number(NAN);
         return TSC_JSON_SUCCESS;
     }
 
@@ -661,7 +415,6 @@ static tsc_json_error_t tsc_json_decode_any(
         s[*idx + 6] == 'y'
     ) {
         *idx += 7;
-        *out = tsc_number(INFINITY);
         return TSC_JSON_SUCCESS;
     }
 
@@ -676,38 +429,618 @@ static tsc_json_error_t tsc_json_decode_any(
         s[*idx + 7] == 'y'
     ) {
         *idx += 8;
-        *out = tsc_number(-INFINITY);
         return TSC_JSON_SUCCESS;
     }
 
     (*idx)--;
-    if (tsc_json_decode_number(s, idx, out)) return TSC_JSON_SUCCESS;
+    if (tsc_json_measure_number(s, idx)) {
+        (*stack_size)++;
+        return TSC_JSON_SUCCESS;
+    }
     return TSC_JSON_ERROR(EXPECTED_ANY, *idx);
 }
 
+static const char *tsc_json_stack_skip_whitespace(const char *s) {
+    while (1) {
+        unsigned char c = *s;
+        if (c == '\0') break;
+        if (TSC_JSON_ISSPACE[c]) {
+            s++;
+            continue;
+        }
+
+        if (c == '/') {
+            s++;
+            c = *s;
+            if (c == '/') {
+                while (1) {
+                    c = *s;
+                    s += c != '\0';
+                    if (c == '\0' || c == '\n') break;
+                }
+                continue;
+            }
+            if (c == '*') {
+                while (1) {
+                    c = *s++;
+                    if (c == '*' && *s == '/') {
+                        s++;
+                        break;
+                    }
+                }
+                continue;
+            }
+        }
+        break;
+    }
+    return s;
+}
+
+// Number format:
+// T - type int:00 hex:01 bin:10 float:11
+// s - string size
+// TT ss ss ss  ss ss ss ss
+// 10 00 00 00  11 10 10 10
+static const char *tsc_json_stack_number(const char *s, tscjson_stack_t *stack) {
+    tscjson_stack_t own_stack = *stack;
+    (*stack)++;
+
+    const char *start = s;
+    int type = 0;
+
+    if (*s == '-') s++;
+
+    if (*s == '0') {
+        s++;
+        if (*s == 'x') {
+            type = 1;
+            s++;
+            while (TSC_JSON_ISXDIGIT[(unsigned char)*s]) s++;
+        }
+        else if (*s == 'b') {
+            type = 2;
+            s++;
+            while (*s == '0' || *s == '1') s++;
+        }
+    }
+    else if (TSC_JSON_ISDIGIT[(unsigned char)*s]) {
+        s++;
+        while (TSC_JSON_ISDIGIT[(unsigned char)*s]) s++;
+    }
+
+    if (type == 0) {
+        if (*s == '.') {
+            type = 3;
+            s++;
+            while (TSC_JSON_ISDIGIT[(unsigned char)*s]) s++;
+        }
+
+        if (*s == 'e' || *s == 'E') {
+            type = 3;
+            s++;
+            if (*s == '+' || *s == '-') s++;
+            while (TSC_JSON_ISDIGIT[(unsigned char)*s]) s++;
+        }
+    }
+
+    static const uint64_t thing[8] = {0x3F, 0x3FFF, 0x3FFFFF, 0x3FFFFFFF, 0x3FFFFFFFFF, 0x3FFFFFFFFFFF, 0x3FFFFFFFFFFFFF, 0x3FFFFFFFFFFFFF};
+    *own_stack = (tscjson_stack_type_t)(type            << (sizeof(tscjson_stack_type_t)*8-2)) |
+                 (tscjson_stack_type_t)((s - start) & thing[sizeof(tscjson_stack_type_t) - 1]);
+    return s;
+}
+
+static const char *tsc_json_stack_string(const char *s, tscjson_stack_t *stack) {
+    tscjson_stack_t own_stack = *stack;
+    (*stack)++;
+    (*own_stack)++; // \0!!!!!!!
+
+    while (1) {
+        const char c = *s;
+        if (c == '"') {
+            s++;
+            break;
+        }
+        if (c == '\\') {
+            s++;
+            const char esc = *s++;
+
+            if (TSC_JSON_BACKSLASH[(unsigned char)esc]) {
+                (*own_stack)++;
+            }
+            else if (esc == 'x') {
+                s += 2;
+                *own_stack += 1;
+            }
+            else if (esc == 'u') {
+                const unsigned int cp =
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[0]] << 12 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[1]] << 8 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[2]] << 4 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[3]];
+
+                s += 4;
+
+                if (0xd800 <= cp && cp <= 0xdbff) {
+                    s += 2;
+                    const unsigned int cp2 =
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[0]] << 12 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[1]] << 8 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[2]] << 4 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[3]];
+
+                    if (0xdc00 <= cp2 && cp2 <= 0xdfff) {
+                        s += 4;
+                        *own_stack += 4;
+                    }
+				}
+                else {
+                    if (cp <= 0x7F) {
+                        *own_stack += 1;
+                    }
+                    else if (cp <= 0x7FF) {
+                        *own_stack += 2;
+                    }
+                    else {
+                        *own_stack += 3;
+                    }
+                }
+            }
+            else if (esc == 'U') {
+                const unsigned int cp =
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[0]] << 28 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[1]] << 24 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[2]] << 20 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[3]] << 16 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[4]] << 12 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[5]] << 8 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[6]] << 4 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)s[7]];
+
+                s += 8;
+
+                if (cp <= 0x7F) {
+                    *own_stack += 1;
+                }
+                else if (cp <= 0x7FF) {
+                    *own_stack += 2;
+                }
+                else if (cp <= 0xFFFF) {
+                    *own_stack += 3;
+                }
+                else {
+                    *own_stack += 4;
+                }
+            }
+            continue;
+        }
+
+        const unsigned char b0 = (unsigned char)*s;
+
+        if ((b0 & 0x80) == 0) {
+            s++;
+            *own_stack += 1;
+        }
+        else if ((b0 & 0xE0) == 0xC0) {
+            s += 2;
+            *own_stack += 2;
+        }
+        else if ((b0 & 0xF0) == 0xE0) {
+            s += 3;
+            *own_stack += 3;
+        }
+        else if ((b0 & 0xF8) == 0xF0) {
+            s += 4;
+            *own_stack += 4;
+        }
+    }
+
+    return s;
+}
+
+static const char *tsc_json_stack_any(const char *s, tscjson_stack_t *stack);
+
+static const char *tsc_json_stack_object(const char *s, tscjson_stack_t *stack) {
+    tscjson_stack_t own_stack = *stack;
+    (*stack)++;
+
+    s = tsc_json_stack_skip_whitespace(s);
+
+    if (*s == '}') {
+        s++;
+        return s;
+    }
+
+    while (1) {
+        (*own_stack)++;
+
+        s = tsc_json_stack_skip_whitespace(s);
+        // Next char is '"'
+        s++;
+        s = tsc_json_stack_string(s, stack);
+
+        s = tsc_json_stack_skip_whitespace(s);
+        // Next char is ':'
+        s++;
+        s = tsc_json_stack_any(s, stack);
+        s = tsc_json_stack_skip_whitespace(s);
+
+        const char sep = *s++;
+        if (sep == '}') return s;
+        if (sep == ',') {
+            s = tsc_json_stack_skip_whitespace(s);
+            if (*s == '}') {
+                s++;
+                return s;
+            }
+        }
+    }
+}
+
+static const char *tsc_json_stack_array(const char *s, tscjson_stack_t *stack) {
+    tscjson_stack_t own_stack = *stack;
+    (*stack)++;
+
+    s = tsc_json_stack_skip_whitespace(s);
+
+    if (*s == ']') {
+        s++;
+        return s;
+    }
+
+    while (1) {
+        (*own_stack)++;
+        s = tsc_json_stack_any(s, stack);
+        s = tsc_json_stack_skip_whitespace(s);
+
+        const char sep = *s++;
+        if (sep == ']') return s;
+
+        if (sep == ',') {
+            s = tsc_json_stack_skip_whitespace(s);
+            if (*s == ']') {
+                s++;
+                return s;
+            }
+        }
+    }
+}
+
+static const char *tsc_json_stack_any(const char* s, tscjson_stack_t *stack) {
+    s = tsc_json_stack_skip_whitespace(s);
+    if (*s == '{') return tsc_json_stack_object(s + 1, stack);
+    if (*s == '[') return tsc_json_stack_array(s + 1, stack);
+    if (*s == '"') return tsc_json_stack_string(s + 1, stack);
+    if (*s == 't') return s + 4;
+    if (*s == 'f') return s + 5;
+    if (*s == 'n') return s + 4;
+    if (*s == 'N') return s + 3;
+    if (*s == 'I') return s + 8;
+    if (*s == '-' && s[1] == 'I') return s + 9;
+    return tsc_json_stack_number(s, stack);
+}
+
+static tsc_value tsc_json_decode_number(const char **s, tscjson_stack_t *stack) {
+    const tscjson_stack_type_t packed = **stack;
+    (*stack)++;
+
+    const char *start = *s;
+    static const uint64_t thing[8] = {0x3F, 0x3FFF, 0x3FFFFF, 0x3FFFFFFF, 0x3FFFFFFFFF, 0x3FFFFFFFFFFF, 0x3FFFFFFFFFFFFF, 0x3FFFFFFFFFFFFF};
+    const uint32_t type = (packed >> (sizeof(tscjson_stack_type_t)*8-2)) & 3;
+    const uint32_t size = packed & thing[sizeof(tscjson_stack_type_t) - 1];
+
+    *s += size;
+
+    size_t i = 0;
+    const int sign = start[i] == '-' ? -1 : 1;
+    if (start[i] == '-') i++;
+
+    // TODO: make it not use glibc
+    // horrible idea i spent a few hours and failed miserably like wtf man
+    if (type == 3) return (tsc_value) { .tag = TSC_VALUE_NUMBER, .number = sign * strtod(start + i, 0) };
+
+    if (type == 2) {
+        i += 2;
+        int64_t result = 0;
+        while (start[i] == '0' || start[i] == '1') {
+            result *= 2;
+            result += start[i] - '0';
+            i++;
+        }
+        return (tsc_value){ .tag = TSC_VALUE_INT, .integer = result * sign };
+    }
+
+    if (type == 1) {
+        i += 2;
+        int64_t result = 0;
+        while (TSC_JSON_ISXDIGIT[(unsigned char)start[i]]) {
+            result *= 16;
+            result += TSC_JSON_XDIGIT[(unsigned char)start[i]];
+            i++;
+        }
+        return (tsc_value){ .tag = TSC_VALUE_INT, .integer = result * sign };
+    }
+
+    {
+        int64_t result = 0;
+        while (TSC_JSON_ISDIGIT[(unsigned char)start[i]]) {
+            result *= 10;
+            result += start[i] - '0';
+            i++;
+        }
+        return (tsc_value){ .tag = TSC_VALUE_INT, .integer = result * sign };
+    }
+}
+
+static int tsc_json_utf8_encode(const unsigned int cp, char *p) {
+    if (cp <= 0x7F) {
+        p[0] = (char)cp;
+        return 1;
+    }
+    if (cp <= 0x7FF) {
+        p[0] = (char)(0xC0 | cp >> 6);
+        p[1] = (char)(0x80 | cp & 0x3F);
+        return 2;
+    }
+    if (cp <= 0xFFFF) {
+        p[0] = (char)(0xE0 | cp >> 12);
+        p[1] = (char)(0x80 | cp >> 6 & 0x3F);
+        p[2] = (char)(0x80 | cp & 0x3F);
+        return 3;
+    }
+    p[0] = (char)(0xF0 | cp >> 18);
+    p[1] = (char)(0x80 | cp >> 12 & 0x3F);
+    p[2] = (char)(0x80 | cp >> 6 & 0x3F);
+    p[3] = (char)(0x80 | cp & 0x3F);
+    return 4;
+}
+
+static char* tsc_json_decode_string(const char **s, tscjson_stack_t *stack, size_t *size) {
+    const tscjson_stack_type_t len = **stack;
+    (*stack)++;
+    if (size != NULL) *size = len;
+    char* b = malloc(len);
+    char* b_begin = b;
+
+    while (**s != '"') {
+        if (**s == '\\') {
+            (*s)++;
+            const char esc = *(*s)++;
+
+            if (TSC_JSON_BACKSLASH[(unsigned char)esc]) {
+                *b++ = TSC_JSON_BACKSLASH[(unsigned char)esc];
+            }
+            else if (esc == 'x') {
+                const unsigned int cp =
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[0]] << 4 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[1]];
+                *s += 2;
+                b += tsc_json_utf8_encode(cp, b);
+            }
+            else if (esc == 'u') {
+                unsigned int cp =
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[0]] << 12 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[1]] << 8 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[2]] << 4 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[3]];
+                *s += 4;
+
+                if (0xd800 <= cp && cp <= 0xdbff) {
+                    const unsigned int cp2 =
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[2]] << 12 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[3]] << 8 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[4]] << 4 |
+                        (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[5]];
+
+                    cp = 0x10000 + (((cp - 0xd800) << 10) | (cp2 - 0xdc00));
+                    *s += 6;
+                }
+                b += tsc_json_utf8_encode(cp, b);
+            }
+            else if (esc == 'U') {
+                const unsigned int cp =
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[0]] << 28 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[1]] << 24 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[2]] << 20 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[3]] << 16 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[4]] << 12 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[5]] << 8 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[6]] << 4 |
+                    (unsigned int)TSC_JSON_XDIGIT[(unsigned char)(*s)[7]];
+                *s += 8;
+                b += tsc_json_utf8_encode(cp, b);
+            }
+        }
+        else {
+            const unsigned char b0 = (unsigned char)(**s);
+
+            if ((b0 & 0x80) == 0) {
+                *b++ = (*s)[0];
+                (*s)++;
+            }
+            else if ((b0 & 0xE0) == 0xC0) {
+                *b++ = (*s)[0];
+                *b++ = (*s)[1];
+                *s += 2;
+            }
+            else if ((b0 & 0xF0) == 0xE0) {
+                *b++ = (*s)[0];
+                *b++ = (*s)[1];
+                *b++ = (*s)[2];
+                *s += 3;
+            }
+            else if ((b0 & 0xF8) == 0xF0) {
+                *b++ = (*s)[0];
+                *b++ = (*s)[1];
+                *b++ = (*s)[2];
+                *b++ = (*s)[3];
+                *s += 4;
+            }
+        }
+    }
+
+    (*s)++;
+    *b = '\0';
+
+    return b_begin;
+}
+
+static tsc_value tsc_json_decode_any(const char **s, tscjson_stack_t *stack);
+
+static tsc_value tsc_json_decode_object(const char **s, tscjson_stack_t *stack) {
+    const tscjson_stack_type_t len = **stack;
+    (*stack)++;
+    tsc_value v;
+    v.tag = TSC_VALUE_OBJECT;
+    v.object = malloc(sizeof(tsc_object_t));
+    v.object->refc = 1;
+    v.object->len = len;
+    v.object->keys = len == 0 ? NULL : malloc(sizeof(char *) * len);
+    v.object->values = len == 0 ? NULL : malloc(sizeof(tsc_value) * len);
+
+    *s = tsc_json_stack_skip_whitespace(*s);
+
+    if (**s == '}') {
+        (*s)++;
+        return v;
+    }
+
+    for (int i = 0;; i++) {
+        *s = tsc_json_stack_skip_whitespace(*s);
+        // Next char is '"'
+        (*s)++;
+        v.object->keys[i] = tsc_json_decode_string(s, stack, NULL);
+        *s = tsc_json_stack_skip_whitespace(*s);
+        // Next char is ':'
+        (*s)++;
+        v.object->values[i] = tsc_json_decode_any(s, stack);
+
+        *s = tsc_json_stack_skip_whitespace(*s);
+
+        const char sep = *(*s)++;
+        if (sep == '}') return v;
+        if (sep == ',') {
+            *s = tsc_json_stack_skip_whitespace(*s);
+            if (**s == '}') {
+                (*s)++;
+                return v;
+            }
+        }
+    }
+}
+
+static tsc_value tsc_json_decode_array(const char **s, tscjson_stack_t *stack) {
+    const tscjson_stack_type_t len = **stack;
+    (*stack)++;
+    tsc_value v;
+    v.tag = TSC_VALUE_ARRAY;
+    v.array = malloc(sizeof(tsc_array_t));
+    v.array->refc = 1;
+    v.array->valuec = len;
+    v.array->values = len == 0 ? NULL : malloc(sizeof(tsc_value) * len);
+
+    *s = tsc_json_stack_skip_whitespace(*s);
+
+    if (**s == ']') {
+        (*s)++;
+        return v;
+    }
+
+    for (int i = 0;; i++) {
+        v.array->values[i] = tsc_json_decode_any(s, stack);
+        *s = tsc_json_stack_skip_whitespace(*s);
+
+        const char sep = *(*s)++;
+        if (sep == ']') return v;
+
+        if (sep == ',') {
+            *s = tsc_json_stack_skip_whitespace(*s);
+            if (**s == ']') {
+                (*s)++;
+                return v;
+            }
+        }
+    }
+}
+
+static tsc_value tsc_json_decode_any(const char **s, tscjson_stack_t *stack) {
+    *s = tsc_json_stack_skip_whitespace(*s);
+    if (**s == '{') {
+        *s += 1;
+        return tsc_json_decode_object(s, stack);
+    }
+    if (**s == '[') {
+        *s += 1;
+        return tsc_json_decode_array(s, stack);
+    }
+    if (**s == '"') {
+        *s += 1;
+        tsc_string_t *string = malloc(sizeof(tsc_string_t));
+        string->refc = 1;
+        string->memory = tsc_json_decode_string(s, stack, &string->len);
+        return (tsc_value){.tag = TSC_VALUE_STRING, {.string = string}};
+    }
+
+    if (**s == 't') {
+        *s += 4;
+        return (tsc_value){.tag = TSC_VALUE_BOOL, {.boolean = 1}};
+    }
+    if (**s == 'f') {
+        *s += 5;
+        return (tsc_value){.tag = TSC_VALUE_BOOL, {.boolean = 0}};
+    }
+    if (**s == 'n') {
+        *s += 4;
+        return (tsc_value){.tag = TSC_VALUE_NULL};
+    }
+    // if this does not work your compiler is a lame sucker
+    if (**s == 'N') {
+        *s += 3;
+        return (tsc_value){.tag = TSC_VALUE_NUMBER, {.number = 0.0/0.0}};
+    }
+    if (**s == 'I') {
+        *s += 7;
+        return (tsc_value){.tag = TSC_VALUE_NUMBER, {.number = 1.0/0.0}};
+    }
+    if (**s == '-' && (*s)[1] == 'I') {
+        *s += 8;
+        return (tsc_value){.tag = TSC_VALUE_NUMBER, {.number = -1.0/0.0}};
+    }
+    return tsc_json_decode_number(s, stack);
+}
+
 tsc_value tsc_json_decode(
-        const char* text,
-        tsc_json_error_t* err
+        const char *text,
+        tsc_json_error_t *err
 ) {
     size_t idx = 0;
-    tsc_value value;
 
-    tsc_json_error_t result = tsc_json_decode_any(text, &idx, &value);
+    int stack_size = 0;
+    tsc_json_error_t result = tsc_json_measure_any(text, &idx, &stack_size);
     if (err != NULL) *err = result;
     if (result.status != TSC_JSON_ERROR_SUCCESS) {
         return tsc_null();
     }
-
-    result = tsc_json_skip_whitespace(text, &idx);
+    result = tsc_json_measure_skip_whitespace(text, &idx);
     if (err != NULL) *err = result;
-    if (result.status != TSC_JSON_ERROR_SUCCESS)  {
+    if (result.status != TSC_JSON_ERROR_SUCCESS) {
         return tsc_null();
     }
-
     if (text[idx] != '\0') {
         if (err != NULL) *err = TSC_JSON_ERROR(TRAILING_CHARACTERS_AFTER_VALUE, idx);
         return tsc_null();
     }
+
+    tscjson_stack_t stack, stack_begin;
+    if (stack_size != 0) {
+        TSC_JSON_ALLOC_STACK(&stack, stack_size * sizeof(stack[0]));
+        stack_begin = stack;
+        TSC_JSON_BZERO_STACK(&stack_begin, stack_size * sizeof(stack[0]));
+        tsc_json_stack_any(text, &stack);
+        stack = stack_begin;
+    }
+
+    const tsc_value val = tsc_json_decode_any(&text, &stack);
+    if (stack_size != 0) TSC_JSON_FREE_STACK(&stack_begin);
     if (err != NULL) *err = TSC_JSON_SUCCESS;
-    return value;
+    return val;
 }

--- a/src/api/tscjson_macros.h
+++ b/src/api/tscjson_macros.h
@@ -6,17 +6,26 @@
 #define INFINITY (1.0f/0.0f)
 #endif
 
-#ifndef NAN
-#define NAN (0.0f/0.0f)
+// Not really but I have no other choice
+#include <stdlib.h>
+typedef uint32_t tscjson_stack_type_t;
+typedef tscjson_stack_type_t* tscjson_stack_t;
+#define TSC_JSON_ALLOC_STACK(s, b) do { (*(s)) = malloc((b)); } while (0)
+#define TSC_JSON_FREE_STACK(s) free(*(s))
+#if defined(__has_builtin)
+    #if __has_builtin(__builtin_bzero)
+        #define TSC_JSON_BZERO_STACK(s, b) __builtin_bzero(*(s), (b))
+    #endif
+#else
+    #if defined(__GNUC__) && !defined(__clang__)
+        #if __GNUC__ >= 3
+            #define TSC_JSON_BZERO_STACK(s, b) __builtin_bzero(*(s), (b))
+        #endif
+    #else
+        #define TSC_JSON_BZERO_STACK(s, b) memset(*(s), 0, b); // bzero() is actually not present in windows api will you believe it
+    #endif
 #endif
 
-#ifndef INT64_MAX
-#define INT64_MAX 9223372036854775807L
-#endif
-
-#ifndef INT64_MIN
-#define INT64_MIN (-9223372036854775808L)
-#endif
 
 static uint64_t double_to_bits(const double d) {
     union {
@@ -36,6 +45,42 @@ static double bits_to_double(const uint64_t u) {
     return conv.d;
 }
 
+static uint64_t int64_to_bits(const int64_t i) {
+    union {
+        int64_t i;
+        uint64_t u;
+    } conv;
+    conv.i = i;
+    return conv.u;
+}
+
+static int64_t bits_to_int64(const uint64_t u) {
+    union {
+        int64_t i;
+        uint64_t u;
+    } conv;
+    conv.u = u;
+    return conv.i;
+}
+
+static uint32_t int32_to_bits(const int32_t i) {
+    union {
+        int32_t i;
+        uint32_t u;
+    } conv;
+    conv.i = i;
+    return conv.u;
+}
+
+static int32_t bits_to_int32(const uint32_t u) {
+    union {
+        int32_t i;
+        uint32_t u;
+    } conv;
+    conv.u = u;
+    return conv.i;
+}
+
 #ifndef isnan
 static int isnan(const double d) {
     uint64_t b = double_to_bits(d);
@@ -44,25 +89,13 @@ static int isnan(const double d) {
 #define isnan isnan
 #endif
 
-#ifndef isinf
-#define isinf(d) (double_to_bits(d) == 0x7FF0000000000000)
-#endif
-
 #ifndef signbit
 #define signbit(d) ((double_to_bits(d) & 0x8000000000000000ULL) != 0)
 #endif
 
 #define flipsign(d) (bits_to_double(double_to_bits(d) ^ 0x8000000000000000ULL))
-
-#ifndef __NO_CTYPE
-#define __NO_CTYPE
-#define isdigit(c) (TSC_JSON_ISDIGIT[(unsigned char)(c)])
-#define isspace(c) (TSC_JSON_ISSPACE[(unsigned char)(c)])
-#define isxdigit(c) (TSC_JSON_ISXDIGIT[(unsigned char)(c)])
-#endif
-
-#ifndef NULL
-#define NULL (void*)0
+#ifndef isinf
+#define isinf(d) (double_to_bits(d) == 0x7FF0000000000000)
 #endif
 
 static const char TSC_JSON_BACKSLASH[256] = {

--- a/src/api/tscjson_macros.h
+++ b/src/api/tscjson_macros.h
@@ -22,7 +22,7 @@ typedef tscjson_stack_type_t* tscjson_stack_t;
             #define TSC_JSON_BZERO_STACK(s, b) __builtin_bzero(*(s), (b))
         #endif
     #else
-        #define TSC_JSON_BZERO_STACK(s, b) memset(*(s), 0, b); // bzero() is actually not present in windows api will you believe it
+        #define TSC_JSON_BZERO_STACK(s, b) memset(*(s), 0, (b)); // bzero() is actually not present in windows api will you believe it
     #endif
 #endif
 


### PR DESCRIPTION
It quite possibly indeed perhaps affirmative should use less memory allocations except for the fact current type system is shit
And if tsc_destroy did not have to clear stuff only 1 total memory allocation would be needed
Also take this from my .bashrc Very funny
```bash
alias wellshit="git remote set-url origin $(git remote get-url origin | sed 's|https://github.com/|git@github.com:|')"
```
